### PR TITLE
refactor: moved from lyne-test to @sbb-esta/lyne-components

### DIFF
--- a/examples/client-side-rendered/angular/README.md
+++ b/examples/client-side-rendered/angular/README.md
@@ -1,8 +1,8 @@
 # Use lyne-components in Angular
 
-1. Install lyne-components as npm-package: `npm install lyne-test --save`
+1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`
 2. In `/src/app/app.module.ts` import the `CUSTOM_ELEMENTS_SCHEMA` and add it to `schemas`
 3. In `/src/main.ts` import `defineCustomElements` and call the function.
-4. Add a new file in the source folder called `lyne-test.d.ts` and declare the module `declare module 'lyne-test/dist/esm/loader';`
+4. Add a new file in the source folder called `lyne-test.d.ts` and declare the module `declare module '@sbb-esta/lyne-components/dist/esm/loader';`
 
 After that you can use lyne-components.

--- a/examples/client-side-rendered/angular/package-lock.json
+++ b/examples/client-side-rendered/angular/package-lock.json
@@ -4386,6 +4386,11 @@
         "read-package-json-fast": "^2.0.3"
       }
     },
+    "@sbb-esta/lyne-components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
+      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+    },
     "@schematics/angular": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-14.0.1.tgz",
@@ -8332,11 +8337,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "lyne-test": {
-      "version": "10.8.3",
-      "resolved": "https://registry.npmjs.org/lyne-test/-/lyne-test-10.8.3.tgz",
-      "integrity": "sha512-DmXogsNnTkbDmAMmNdXjnm+U4NGf9EPOgY3uUH1XwhCK8+RuBS+aL/ddWK7Yqn7S5jO30uHnC4jClaPM/nwlSg=="
-    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -10003,7 +10003,7 @@
         "retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "dev": true
         }
       }
@@ -10645,7 +10645,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "setprototypeof": {

--- a/examples/client-side-rendered/angular/package.json
+++ b/examples/client-side-rendered/angular/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "~13.2.6",
     "@angular/platform-browser-dynamic": "~13.2.6",
     "@angular/router": "~13.2.6",
-    "lyne-test": "~10.8.3",
+    "@sbb-esta/lyne-components": "0.1.2",
     "rxjs": "~7.5.5",
     "tslib": "^2.4.0",
     "zone.js": "~0.11.5"

--- a/examples/client-side-rendered/angular/src/app/app.component.html
+++ b/examples/client-side-rendered/angular/src/app/app.component.html
@@ -1,6 +1,6 @@
-<lyne-button
+<sbb-button
   label="{{buttonLabel}}"
   icon
 >
   <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m17.8436,12.1382-3.99-3.99196-.7072.70693,3.1366,3.13823H5v1h11.287l-3.1413,3.1555.7086.7056,3.99-4.008.3519-.3535-.3526-.3528z"></path></svg>
-</lyne-button>
+</sbb-button>

--- a/examples/client-side-rendered/angular/src/lyne-test.d.ts
+++ b/examples/client-side-rendered/angular/src/lyne-test.d.ts
@@ -1,1 +1,1 @@
-declare module 'lyne-test/dist/esm/loader';
+declare module '@sbb-esta/lyne-components/dist/esm/loader';

--- a/examples/client-side-rendered/angular/src/main.ts
+++ b/examples/client-side-rendered/angular/src/main.ts
@@ -4,7 +4,7 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
-import { defineCustomElements } from 'lyne-test/dist/esm/loader';
+import { defineCustomElements } from '@sbb-esta/lyne-components/dist/esm/loader';
 
 if (environment.production) {
   enableProdMode();

--- a/examples/client-side-rendered/angular/tsconfig.app.json
+++ b/examples/client-side-rendered/angular/tsconfig.app.json
@@ -4,10 +4,10 @@
   "compilerOptions": {
     "outDir": "./out-tsc/app",
     "types": [
-      "lyne-test"
+      "@sbb-esta/lyne-components"
     ],
     "typeRoots": [
-      "./node_modules/lyne-test/"
+      "./node_modules/@sbb-esta/lyne-components/"
     ]
   },
   "files": [

--- a/examples/client-side-rendered/javascript/dist/index.html
+++ b/examples/client-side-rendered/javascript/dist/index.html
@@ -31,14 +31,14 @@
         font-display: fallback;
       }
     </style>
-    <script src="https://unpkg.com/lyne-test/dist/lyne-components/lyne-components.js"></script>
+    <script type="module" src="https://unpkg.com/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.esm.js"></script>
   </head>
   <body>
-    <lyne-button
+    <sbb-button
       label="lyne-cta-button used without any framework"
       icon
     >
       <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m17.8436,12.1382-3.99-3.99196-.7072.70693,3.1366,3.13823H5v1h11.287l-3.1413,3.1555.7086.7056,3.99-4.008.3519-.3535-.3526-.3528z"></path></svg>
-    </lyne-button>
+    </sbb-button>
   </body>
 </html>

--- a/examples/client-side-rendered/react/README.md
+++ b/examples/client-side-rendered/react/README.md
@@ -2,7 +2,7 @@
 
 # Use lyne-components in React
 
-1. Install lyne-components as npm-package: `npm install lyne-test --save`
+1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`
 2. In `/src/index.js` import `defineCustomElements` and call the function.
 
 After that you can use lyne-components.

--- a/examples/client-side-rendered/react/package-lock.json
+++ b/examples/client-side-rendered/react/package-lock.json
@@ -2288,6 +2288,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz",
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
     },
+    "@sbb-esta/lyne-components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
+      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -8891,11 +8896,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "lyne-test": {
-      "version": "10.8.3",
-      "resolved": "https://registry.npmjs.org/lyne-test/-/lyne-test-10.8.3.tgz",
-      "integrity": "sha512-DmXogsNnTkbDmAMmNdXjnm+U4NGf9EPOgY3uUH1XwhCK8+RuBS+aL/ddWK7Yqn7S5jO30uHnC4jClaPM/nwlSg=="
     },
     "lz-string": {
       "version": "1.4.4",

--- a/examples/client-side-rendered/react/package.json
+++ b/examples/client-side-rendered/react/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.2.0",
-    "lyne-test": "~10.8.3",
+    "@sbb-esta/lyne-components": "0.1.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1"

--- a/examples/client-side-rendered/react/src/App.js
+++ b/examples/client-side-rendered/react/src/App.js
@@ -3,12 +3,12 @@ import './css/fonts.css';
 
 function App() {
   return (
-    <lyne-button
+    <sbb-button
       label="lyne-cta-button used in React"
       icon
     >
       <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m17.8436,12.1382-3.99-3.99196-.7072.70693,3.1366,3.13823H5v1h11.287l-3.1413,3.1555.7086.7056,3.99-4.008.3519-.3535-.3526-.3528z"></path></svg>
-    </lyne-button>
+    </sbb-button>
   );
 }
 

--- a/examples/client-side-rendered/react/src/index.js
+++ b/examples/client-side-rendered/react/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import { defineCustomElements } from 'lyne-test/dist/esm/loader';
+import { defineCustomElements } from '@sbb-esta/lyne-components/dist/esm/loader';
 
 defineCustomElements();
 

--- a/examples/client-side-rendered/vue/README.md
+++ b/examples/client-side-rendered/vue/README.md
@@ -2,7 +2,7 @@
 
 # Use lyne-components in Vue
 
-1. Install lyne-components as npm-package: `npm install lyne-test --save`
+1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`
 2. In `/src/main.js` import `defineCustomElements` and call the function.
 
 After that you can use lyne-components.

--- a/examples/client-side-rendered/vue/package-lock.json
+++ b/examples/client-side-rendered/vue/package-lock.json
@@ -2360,6 +2360,11 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@sbb-esta/lyne-components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
+      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -3560,6 +3565,52 @@
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
         "ssri": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -3567,6 +3618,41 @@
           "dev": true,
           "requires": {
             "minipass": "^3.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.8.3",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            }
           }
         }
       }
@@ -9421,11 +9507,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "lyne-test": {
-      "version": "10.8.3",
-      "resolved": "https://registry.npmjs.org/lyne-test/-/lyne-test-10.8.3.tgz",
-      "integrity": "sha512-DmXogsNnTkbDmAMmNdXjnm+U4NGf9EPOgY3uUH1XwhCK8+RuBS+aL/ddWK7Yqn7S5jO30uHnC4jClaPM/nwlSg=="
-    },
     "magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -13480,79 +13561,6 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.8.3",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
-      "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },

--- a/examples/client-side-rendered/vue/package.json
+++ b/examples/client-side-rendered/vue/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.22.8",
-    "lyne-test": "~10.8.3",
+    "@sbb-esta/lyne-components": "0.1.2",
     "vue": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/client-side-rendered/vue/src/components/HelloWorld.vue
+++ b/examples/client-side-rendered/vue/src/components/HelloWorld.vue
@@ -1,8 +1,8 @@
 <template>
-  <lyne-button
+  <sbb-button
     label="lyne-button used in Vue"
     icon
   >
     <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m17.8436,12.1382-3.99-3.99196-.7072.70693,3.1366,3.13823H5v1h11.287l-3.1413,3.1555.7086.7056,3.99-4.008.3519-.3535-.3526-.3528z"></path></svg>
-  </lyne-button>
+  </sbb-button>
 </template>

--- a/examples/client-side-rendered/vue/src/main.js
+++ b/examples/client-side-rendered/vue/src/main.js
@@ -1,6 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
-import { defineCustomElements } from 'lyne-test/dist/esm/loader';
+import { defineCustomElements } from '@sbb-esta/lyne-components/dist/esm/loader';
 
 defineCustomElements();
 

--- a/examples/server-side-rendered/eleventy/.eleventy.js
+++ b/examples/server-side-rendered/eleventy/.eleventy.js
@@ -1,4 +1,4 @@
-const hydrate = require('lyne-test/hydrate')
+const hydrate = require('@sbb-esta/lyne-components/hydrate')
 
 module.exports = function(config) {
   config.addTransform('hydrate', async (content, outputPath) => {

--- a/examples/server-side-rendered/eleventy/README.md
+++ b/examples/server-side-rendered/eleventy/README.md
@@ -6,7 +6,7 @@
 
 We encourage you to use server and client side hydration whenever possible. This repo shows how to do it.
 
-1. Install `lyne-components` as a dependency.
+1. Install `@sbb-esta/lyne-components` as a dependency.
 2. Load the `lyne-components` with script tag. See `layout.njk` for an example.
 3. Add a transform to `.eleventy.js`. Use our `hydrate` script to render the page contents to a string.
 4. Use the components as usual. See `index.njk` for an example.

--- a/examples/server-side-rendered/eleventy/package-lock.json
+++ b/examples/server-side-rendered/eleventy/package-lock.json
@@ -115,6 +115,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sbb-esta/lyne-components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
+      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+    },
     "@sindresorhus/slugify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
@@ -1500,11 +1505,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.2.tgz",
       "integrity": "sha512-MlAQQVMFhGk4WUA6gpfsy0QycnKP0+NlCBJRVRNPxxSIbjrCbQ65nrpJD3FVyJNZLuJ0uoqL57ye6BmDYgHaSw==",
       "dev": true
-    },
-    "lyne-test": {
-      "version": "10.8.3",
-      "resolved": "https://registry.npmjs.org/lyne-test/-/lyne-test-10.8.3.tgz",
-      "integrity": "sha512-DmXogsNnTkbDmAMmNdXjnm+U4NGf9EPOgY3uUH1XwhCK8+RuBS+aL/ddWK7Yqn7S5jO30uHnC4jClaPM/nwlSg=="
     },
     "markdown-it": {
       "version": "12.3.2",

--- a/examples/server-side-rendered/eleventy/package.json
+++ b/examples/server-side-rendered/eleventy/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "copy:components": "mkdir -p dist/js && ncp ./node_modules/lyne-test/ ./dist/js/lyne-test/",
+    "copy:components": "mkdir -p dist/js && ncp ./node_modules/@sbb-esta/lyne-components/ ./dist/js/lyne-components/",
     "start": "npm run copy:components & npx @11ty/eleventy --serve",
     "build": "npm run copy:components & npx @11ty/eleventy"
   },
@@ -15,6 +15,6 @@
     "ncp": "~2.0.0"
   },
   "dependencies": {
-    "lyne-test": "~10.8.1"
+    "@sbb-esta/lyne-components": "0.1.2"
   }
 }

--- a/examples/server-side-rendered/eleventy/src/includes/layout.njk
+++ b/examples/server-side-rendered/eleventy/src/includes/layout.njk
@@ -32,9 +32,7 @@
       }
     </style>
 
-    <script type="module" src="/js/lyne-test/dist/lyne-components/lyne-components.esm.js"></script>
-
-    <script nomodule src="/js/lyne-test/dist/lyne-components/lyne-components.js"></script>
+    <script type="module" src="/js/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.esm.js"></script>
 
   </head>
   <body>

--- a/examples/server-side-rendered/eleventy/src/index.njk
+++ b/examples/server-side-rendered/eleventy/src/index.njk
@@ -4,7 +4,7 @@ layout: layout.njk
 
 <h1>Hydration</h1>
 
-<p>Our components need Javascript to be interpreted, displayed and behave correctly (interaction). Without hydration, clients would first need to download our StencilJS loader and execute it, so that the browser understands our custom-elements (on this page, lyne-button is an unknown html element for the browser).</p>
+<p>Our components need Javascript to be interpreted, displayed and behave correctly (interaction). Without hydration, clients would first need to download our StencilJS loader and execute it, so that the browser understands our custom-elements (on this page, sbb-button is an unknown html element for the browser).</p>
 
 <p>In the server-side hydration, we make part of this "interpretation" on the server, rendering the contents of the component to plain html, and attaching all the css-classes needed for the component to have the correct appearance.</p>
 
@@ -19,33 +19,33 @@ layout: layout.njk
 
 <p>The button dispatches an event on click with JavaScript. In this file, we're listening to that event and showing an alert as soon as it is received.</p>
 <p>So if the alert shows up if you click on the button, that means that client-side hydration is working (make sure you enable JavaScript again).</p>
-<lyne-button event-id="eleventy-event"></lyne-button>
+<sbb-button event-id="eleventy-event" label="This is a button"></sbb-button>
 
 <h2>Component with named slots</h2>
-<lyne-accordion aria-labelledby="">
-    <lyne-accordion-item event-id="id1" heading="Accordion Item 1" heading-level="2" icon="">
+<sbb-accordion aria-labelledby="">
+    <sbb-accordion-item event-id="id1" heading="Accordion Item 1" heading-level="2" icon="">
         <p slot="content">1 Donec sed odio operae, eu vulputate felis rhoncus. Curabitur est gravida et libero vitae dictum. Me non paenitet nullum festiviorem excogitasse ad hoc.</p>
         <p slot="content">2 Donec sed odio operae, eu vulputate felis rhoncus. Curabitur est gravida et libero vitae dictum. Me non paenitet nullum festiviorem excogitasse ad hoc.</p>
         <p slot="content">3 Quis aute iure reprehenderit in voluptate velit esse. Ab illo tempore, ab est sed immemorabili. Non equidem invideo, lit aliquet. Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae.</p>
         <svg slot="icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m17.8436,12.1382-3.99-3.99196-.7072.70693,3.1366,3.13823H5v1h11.287l-3.1413,3.1555.7086.7056,3.99-4.008.3519-.3535-.3526-.3528z"></path></svg>
-    </lyne-accordion-item>
+    </sbb-accordion-item>
 
-    <lyne-accordion-item heading="Accordion Item 2" heading-level="2">
+    <sbb-accordion-item heading="Accordion Item 2" heading-level="2">
         <p slot="content">1 Donec sed odio operae, eu vulputate felis rhoncus. Curabitur est gravida et libero vitae dictum. Me non paenitet nullum festiviorem excogitasse ad hoc.</p>
         <p slot="content">2 Donec sed odio operae, eu vulputate felis rhoncus. Curabitur est gravida et libero vitae dictum. Me non paenitet nullum festiviorem excogitasse ad hoc.</p>
         <p slot="content">3 Quis aute iure reprehenderit in voluptate velit esse. Ab illo tempore, ab est sed immemorabili. Non equidem invideo, lit aliquet. Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae.</p>
-    </lyne-accordion-item>
+    </sbb-accordion-item>
 
-    <lyne-accordion-item event-id="id3" heading="Accordion Item 3" heading-level="2" icon="">
+    <sbb-accordion-item event-id="id3" heading="Accordion Item 3" heading-level="2" icon="">
         <p slot="content">1 Donec sed odio operae, eu vulputate felis rhoncus. Curabitur est gravida et libero vitae dictum. Me non paenitet nullum festiviorem excogitasse ad hoc.</p>
         <p slot="content">2 Donec sed odio operae, eu vulputate felis rhoncus. Curabitur est gravida et libero vitae dictum. Me non paenitet nullum festiviorem excogitasse ad hoc.</p>
         <p slot="content">3 Quis aute iure reprehenderit in voluptate velit esse. Ab illo tempore, ab est sed immemorabili. Non equidem invideo, lit aliquet. Nihilne te nocturnum praesidium Palati, nihil urbis vigiliae.</p>
         <svg slot="icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="m17.8436,12.1382-3.99-3.99196-.7072.70693,3.1366,3.13823H5v1h11.287l-3.1413,3.1555.7086.7056,3.99-4.008.3519-.3535-.3526-.3528z"></path></svg>
-    </lyne-accordion-item>
-</lyne-accordion>
+    </sbb-accordion-item>
+</sbb-accordion>
 
 <script>
-window.addEventListener('lyne-button_click', function(data) {
+window.addEventListener('sbb-button_click', function(data) {
     alert("Event received with event-id: " + data.detail);
 });
 </script>


### PR DESCRIPTION
As the new @ sbb-esta/lyne-components library is available, all references to the old one (lyne-test) have been removed, including the renaming of the components from "lyne-<component>" to "sbb-<component>".

@lyne-design-system/core 