### PR TITLE
feat: add import for lyne-components stylesheet

### DIFF
--- a/examples/client-side-rendered/angular/README.md
+++ b/examples/client-side-rendered/angular/README.md
@@ -1,8 +1,9 @@
 # Use lyne-components in Angular
 
-1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`
-2. In `/src/app/app.module.ts` import the `CUSTOM_ELEMENTS_SCHEMA` and add it to `schemas`
+1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`.
+2. In `/src/app/app.module.ts` import the `CUSTOM_ELEMENTS_SCHEMA` and add it to `schemas`.
 3. In `/src/main.ts` import `defineCustomElements` and call the function.
-4. Add a new file in the source folder called `lyne-test.d.ts` and declare the module `declare module '@sbb-esta/lyne-components/dist/esm/loader';`
+4. In `angular.json` add `"node_modules/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.css"` in the 'styles' array property under build options.
+5. Add a new file in the source folder called `lyne-test.d.ts` and declare the module `declare module '@sbb-esta/lyne-components/dist/esm/loader';`.
 
 After that you can use lyne-components.

--- a/examples/client-side-rendered/angular/angular.json
+++ b/examples/client-side-rendered/angular/angular.json
@@ -27,7 +27,8 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.css"
+              "src/styles.css",
+              "node_modules/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.css"
             ],
             "scripts": []
           },

--- a/examples/client-side-rendered/angular/package-lock.json
+++ b/examples/client-side-rendered/angular/package-lock.json
@@ -4387,9 +4387,9 @@
       }
     },
     "@sbb-esta/lyne-components": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
-      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.8.tgz",
+      "integrity": "sha512-3AFQBaiyenmJ1forYyuZJOWG/QYRmHrtpORkHr9xT5HvZR/6v0ZZxZ8k6a4/JtVBnAKtxT2dH4M1/wSxs6ebHw=="
     },
     "@schematics/angular": {
       "version": "14.0.1",

--- a/examples/client-side-rendered/angular/package.json
+++ b/examples/client-side-rendered/angular/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "~13.2.6",
     "@angular/platform-browser-dynamic": "~13.2.6",
     "@angular/router": "~13.2.6",
-    "@sbb-esta/lyne-components": "0.1.2",
+    "@sbb-esta/lyne-components": "0.1.8",
     "rxjs": "~7.5.5",
     "tslib": "^2.4.0",
     "zone.js": "~0.11.5"

--- a/examples/client-side-rendered/javascript/dist/index.html
+++ b/examples/client-side-rendered/javascript/dist/index.html
@@ -35,7 +35,6 @@
     <script type="module" src="https://unpkg.com/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.esm.js"></script>
   </head>
   <body>
-  <h2>Ciao</h2>
     <sbb-button
       label="lyne-cta-button used without any framework"
       icon

--- a/examples/client-side-rendered/javascript/dist/index.html
+++ b/examples/client-side-rendered/javascript/dist/index.html
@@ -31,9 +31,11 @@
         font-display: fallback;
       }
     </style>
+    <link rel="stylesheet" href="https://unpkg.com/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.css"/>
     <script type="module" src="https://unpkg.com/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.esm.js"></script>
   </head>
   <body>
+  <h2>Ciao</h2>
     <sbb-button
       label="lyne-cta-button used without any framework"
       icon

--- a/examples/client-side-rendered/react/README.md
+++ b/examples/client-side-rendered/react/README.md
@@ -2,7 +2,9 @@
 
 # Use lyne-components in React
 
-1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`
+1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`.
 2. In `/src/index.js` import `defineCustomElements` and call the function.
+3. In `/src/App.js` add `import '@sbb-esta/lyne-components/dist/lyne-components/lyne-components.css';`.
+
 
 After that you can use lyne-components.

--- a/examples/client-side-rendered/react/package-lock.json
+++ b/examples/client-side-rendered/react/package-lock.json
@@ -2289,9 +2289,9 @@
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
     },
     "@sbb-esta/lyne-components": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
-      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.8.tgz",
+      "integrity": "sha512-3AFQBaiyenmJ1forYyuZJOWG/QYRmHrtpORkHr9xT5HvZR/6v0ZZxZ8k6a4/JtVBnAKtxT2dH4M1/wSxs6ebHw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/examples/client-side-rendered/react/package.json
+++ b/examples/client-side-rendered/react/package.json
@@ -6,7 +6,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.2.0",
-    "@sbb-esta/lyne-components": "0.1.2",
+    "@sbb-esta/lyne-components": "0.1.8",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1"

--- a/examples/client-side-rendered/react/src/App.js
+++ b/examples/client-side-rendered/react/src/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import '@sbb-esta/lyne-components/dist/lyne-components/lyne-components.css';
 import './css/fonts.css';
 
 function App() {

--- a/examples/client-side-rendered/vue/README.md
+++ b/examples/client-side-rendered/vue/README.md
@@ -2,7 +2,8 @@
 
 # Use lyne-components in Vue
 
-1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`
+1. Install lyne-components as npm-package: `npm install @sbb-esta/lyne-components --save`.
 2. In `/src/main.js` import `defineCustomElements` and call the function.
+2. In `/src/main.js` add `import '@sbb-esta/lyne-components/dist/lyne-components/lyne-components.css';`.
 
 After that you can use lyne-components.

--- a/examples/client-side-rendered/vue/package-lock.json
+++ b/examples/client-side-rendered/vue/package-lock.json
@@ -2361,9 +2361,9 @@
       "dev": true
     },
     "@sbb-esta/lyne-components": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
-      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.8.tgz",
+      "integrity": "sha512-3AFQBaiyenmJ1forYyuZJOWG/QYRmHrtpORkHr9xT5HvZR/6v0ZZxZ8k6a4/JtVBnAKtxT2dH4M1/wSxs6ebHw=="
     },
     "@sideway/address": {
       "version": "4.1.4",

--- a/examples/client-side-rendered/vue/package.json
+++ b/examples/client-side-rendered/vue/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.22.8",
-    "@sbb-esta/lyne-components": "0.1.2",
+    "@sbb-esta/lyne-components": "0.1.8",
     "vue": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/client-side-rendered/vue/src/main.js
+++ b/examples/client-side-rendered/vue/src/main.js
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import '@sbb-esta/lyne-components/dist/lyne-components/lyne-components.css';
 import { defineCustomElements } from '@sbb-esta/lyne-components/dist/esm/loader';
 
 defineCustomElements();

--- a/examples/server-side-rendered/eleventy/README.md
+++ b/examples/server-side-rendered/eleventy/README.md
@@ -7,7 +7,7 @@
 We encourage you to use server and client side hydration whenever possible. This repo shows how to do it.
 
 1. Install `@sbb-esta/lyne-components` as a dependency.
-2. Load the `lyne-components` with script tag. See `layout.njk` for an example.
+2. Load the `lyne-components` with script tag and add the import of the stylesheet. See `layout.njk` for an example.
 3. Add a transform to `.eleventy.js`. Use our `hydrate` script to render the page contents to a string.
 4. Use the components as usual. See `index.njk` for an example.
 

--- a/examples/server-side-rendered/eleventy/package-lock.json
+++ b/examples/server-side-rendered/eleventy/package-lock.json
@@ -116,9 +116,9 @@
       }
     },
     "@sbb-esta/lyne-components": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.2.tgz",
-      "integrity": "sha512-I2duLbe+bYHIk5H33xk3hLDdQRmL2Ysqdjd5dl9vpYrpYuqhYhmbULGTpfKTCWU6YeD+r+SfRC/v3Q8GV97JKw=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@sbb-esta/lyne-components/-/lyne-components-0.1.8.tgz",
+      "integrity": "sha512-3AFQBaiyenmJ1forYyuZJOWG/QYRmHrtpORkHr9xT5HvZR/6v0ZZxZ8k6a4/JtVBnAKtxT2dH4M1/wSxs6ebHw=="
     },
     "@sindresorhus/slugify": {
       "version": "1.1.2",

--- a/examples/server-side-rendered/eleventy/package.json
+++ b/examples/server-side-rendered/eleventy/package.json
@@ -15,6 +15,6 @@
     "ncp": "~2.0.0"
   },
   "dependencies": {
-    "@sbb-esta/lyne-components": "0.1.2"
+    "@sbb-esta/lyne-components": "0.1.8"
   }
 }

--- a/examples/server-side-rendered/eleventy/src/includes/layout.njk
+++ b/examples/server-side-rendered/eleventy/src/includes/layout.njk
@@ -32,7 +32,8 @@
       }
     </style>
 
-    <script type="module" src="/js/@sbb-esta/lyne-components/dist/lyne-components/lyne-components.esm.js"></script>
+    <link rel="stylesheet" href="js/lyne-components/dist/lyne-components/lyne-components.css"/>
+    <script type="module" src="/js/lyne-components/dist/lyne-components/lyne-components.esm.js"></script>
 
   </head>
   <body>


### PR DESCRIPTION
Since the stylesheet system on @sbb-esta/lyne-components has been simplified and standalone-mode removed, there is the need to explicitly import the lyne-components stylesheet.